### PR TITLE
fix - 채팅방 동일 사용자 참가 금지 로직 추가 및 member img update시 에러에 대한 해결

### DIFF
--- a/src/main/java/com/example/server/chat/domain/model/entity/MemberChatRoom.java
+++ b/src/main/java/com/example/server/chat/domain/model/entity/MemberChatRoom.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;

--- a/src/main/java/com/example/server/chat/domain/repository/custom/CustomMemberChatRoomRepository.java
+++ b/src/main/java/com/example/server/chat/domain/repository/custom/CustomMemberChatRoomRepository.java
@@ -1,8 +1,10 @@
 package com.example.server.chat.domain.repository.custom;
 
 import com.example.server.chat.domain.model.entity.ChatRoom;
+import com.example.server.chat.domain.model.entity.MemberChatRoom;
 import com.example.server.chat.domain.repository.dto.ChatRoomListResponse;
 import com.example.server.chat.domain.repository.dto.QChatRoomListResponse;
+import com.example.server.member.Member;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -52,6 +54,17 @@ public class CustomMemberChatRoomRepository extends QuerydslRepositorySupport {
                         .and(promiseMember.accepted.eq("Y")))
                 .groupBy(memberChatRoom.chatRoom().id)
                 .orderBy(chatMessage.sentDate.max().desc())
+                .fetch();
+    }
+
+    @Transactional
+    public List<MemberChatRoom> findExistMemberInChatRoomByMemberId(List<Long> memberIds, Long roomId) {
+        return queryFactory
+                .selectFrom(memberChatRoom)
+                .where(
+                        memberChatRoom.member().memberId.in(memberIds)
+                                .and(memberChatRoom.chatRoom().id.eq(roomId))
+                )
                 .fetch();
     }
 

--- a/src/main/java/com/example/server/member/CustomMemberRepository.java
+++ b/src/main/java/com/example/server/member/CustomMemberRepository.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.example.server.member.QAuthority.authority;
 import static com.example.server.member.QMember.member;
@@ -75,7 +76,14 @@ public class CustomMemberRepository extends QuerydslRepositorySupport {
         String newPassword = request.get("password") == null ?
                 member.getPassword() : request.get("password");
 
-        String newImg = request.get("img") == null ? member.getImg() : request.get("img");
+        String newImg;
+        if(request.get("img").equals("")) {
+            newImg = null;
+        } else if(Objects.isNull(request.get("img"))) {
+            newImg = member.getImg();
+        } else {
+            newImg = request.get("img");
+        }
 
         String memberRelatedEntitiesUpdateQuery = "UPDATE Member m " +
                 "LEFT JOIN Friend f ON m.nickname = f.requester OR m.nickname = f.respondent " +

--- a/src/main/java/com/example/server/push/service/PushService.java
+++ b/src/main/java/com/example/server/push/service/PushService.java
@@ -14,9 +14,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
-import static com.example.server.push.contatns.PushCategory.*;
+import static com.example.server.push.contatns.PushCategory.FRIEND_REQUEST;
+import static com.example.server.push.contatns.PushCategory.PROMISE_REQUEST;
 
 @Service
 @Slf4j
@@ -30,6 +32,12 @@ public class PushService {
 
     public void makeAndSendPushNotification(PushCategory pushCategory, String account) {
         String payload = makePayload(pushCategory);
+        String deviceToken = redisClient.getDeviceToken(account);
+
+        if(Objects.isNull(deviceToken)) {
+            throw new RuntimeException("등록된 Device Token 값이 없습니다.");
+        }
+
         String token = TokenUtil.sanitizeTokenString(redisClient.getDeviceToken(account));
 
         SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(token, bundleId, payload);


### PR DESCRIPTION
Changes
---
- 채팅방 생성할 때 동일한 닉네임이 2개 있을 경우 참가 금지
- member가 img가 있을 때에 null로 바꾸고 싶을 때에 대한 로직 추가